### PR TITLE
small refactoring

### DIFF
--- a/force-app/main/default/classes/HttpMock.cls
+++ b/force-app/main/default/classes/HttpMock.cls
@@ -50,13 +50,22 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
         // Headers
         HttpMock header(String key, String value);
         // Mock
-        HttpMock mock();
+        void mock();
+    }
+
+    public static Integer getRequestCount(String httpMethod, String endpoint) {
+        if (!requestCountByMethodAndEndpoint.containsKey(httpMethod)) {
+            return 0;
+        }
+
+        return requestCountByMethodAndEndpoint.get(httpMethod).get(endpoint) ?? 0;
     }
 
     // Implementation
 
-    private Map<String, Map<String, HttpResponse>> mocks = new Map<String, Map<String, HttpResponse>>();
-    private Map<String, Map<String, Integer>> requestCountByMethodAndEndpoint = new Map<String, Map<String, Integer>>();
+    private static Map<String, Map<String, HttpResponse>> mocks = new Map<String, Map<String, HttpResponse>>();
+    private static Map<String, Map<String, Integer>> requestCountByMethodAndEndpoint = new Map<String, Map<String, Integer>>();
+
     private HttpResponse workingHttpResponse = null;
 
     public HttpMock get(String endpointToMock) {
@@ -92,13 +101,13 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
             mocks.put(httpMethod, new Map<String, HttpResponse>());
         }
 
-        workingHttpResponse = new HttpResponse();
+        this.workingHttpResponse = new HttpResponse();
 
         body('{}');
         contentTypeJson();
         statusCodeOk();
 
-        mocks.get(httpMethod).put(endpointToMock, workingHttpResponse);
+        mocks.get(httpMethod).put(endpointToMock, this.workingHttpResponse);
 
         return this;
     }
@@ -108,12 +117,12 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
     }
 
     public HttpMock body(String body) {
-        workingHttpResponse.setBody(body);
+        this.workingHttpResponse.setBody(body);
         return this;
     }
 
     public HttpMock body(Blob body) {
-        workingHttpResponse.setBodyAsBlob(body);
+        this.workingHttpResponse.setBodyAsBlob(body);
         return this;
     }
 
@@ -150,7 +159,7 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
     }
 
     public HttpMock header(String key, String value) {
-        workingHttpResponse.setHeader(key, value);
+        this.workingHttpResponse.setHeader(key, value);
         return this;
     }
 
@@ -211,21 +220,12 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
     }
 
     public HttpMock statusCode(Integer statusCode) {
-        workingHttpResponse.setStatusCode(statusCode);
+        this.workingHttpResponse.setStatusCode(statusCode);
         return this;
     }
 
-    public HttpMock mock() {
+    public void mock() {
         Test.setMock(HttpCalloutMock.class, this);
-        return this;
-    }
-
-    public Integer getRequestCount(String httpMethod, String endpoint) {
-        if (!requestCountByMethodAndEndpoint.containsKey(httpMethod)) {
-            return 0;
-        }
-
-        return requestCountByMethodAndEndpoint.get(httpMethod).get(endpoint) ?? 0;
     }
 
     public HttpResponse respond(HttpRequest request) {

--- a/force-app/main/default/classes/HttpMockTest.cls
+++ b/force-app/main/default/classes/HttpMockTest.cls
@@ -511,14 +511,14 @@ private class HttpMockTest {
 
     @IsTest
     static void getRequestCount() {
-        HttpMock httpMock = new HttpMock().get('/api/v1').statusCodeOk().mock();
+        new HttpMock().get('/api/v1').statusCodeOk().mock();
 
         Test.startTest();
         new TestApi().makeCallout('GET', '/api/v1');
         new TestApi().makeCallout('GET', '/api/v1');
         Test.stopTest();
 
-        Assert.areEqual(2, httpMock.getRequestCount('GET', '/api/v1'));
+        Assert.areEqual(2, HttpMock.getRequestCount('GET', '/api/v1'));
     }
 
     @IsTest


### PR DESCRIPTION
@bartoszsuchocki malutki refactor. 

1. Zostawiłem `void mock()` tak, aby ktoś nie zrobił jakiegoś dziwnego chaina:

```java
new HttpMock()
            .get('/api/v1/authorize').body('{ "token": "aZ3Xb7Qk" }').statusCodeOk()
            .post('/api/v1/create').body('{ "success": true, "message": null }').statusCodeOk()
            .mock()
            .post('/api/v1/create').body('{ "success": true, "message": null }').statusCodeOk();
```

bo bez voida będzie się dało a tak void będzie ostatecznym zawołaniem. 

2. Dałem ten counter i pobieranie go jako static, bo w zasadzie to jak taka zmienna statyczna, która zbiera co i ile razy się wykonało w transakcji i nie musi być to atrybutem klasy, ale i całej transakcji, a i kodzik będzie prostszy, bo po wykonaniu kodu można po prostu wywołać `HttpMock.getRequestCount(.., ...);`