### PR TITLE
Add Support for uploading Static Resources for Mocking

### DIFF
--- a/force-app/main/default/classes/HttpMock.cls
+++ b/force-app/main/default/classes/HttpMock.cls
@@ -35,6 +35,8 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
         HttpMock contentTypePdf(); // application/pdf
         HttpMock contentTypeFormUrlencoded(); // application/x-www-form-urlencoded
         HttpMock contentType(String contentType);
+        // Static Resource
+        HttpMock staticResource(String staticResourceName);
         // Status Code
         HttpMock statusCodeOk(); // 200
         HttpMock statusCodeCreated(); // 201
@@ -175,6 +177,17 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
         return this;
     }
 
+    public HttpMock staticResource(String staticResourceName) {
+        StaticResource staticResource = null;
+        try {
+            staticResource = [SELECT Body FROM StaticResource WHERE Name = :staticResourceName LIMIT 1];
+        } catch (QueryException queryEx) {
+            throw new StaticResourceNotFoundException('Static Resource "' + staticResourceName + '" not found.');
+        }
+        
+        return this.body(staticResource.Body);
+    }
+
     public HttpMock statusCodeOk() {
         return this.statusCode(200);
     }
@@ -302,4 +315,5 @@ public class HttpMock implements HttpMockLib, HttpCalloutMock {
 
     public class HttpMethodNotMockedException extends Exception {}
     public class HttpEndpointNotMockedException extends Exception {}
+    public class StaticResourceNotFoundException extends Exception {}
 }

--- a/force-app/main/default/classes/HttpMockTest.cls
+++ b/force-app/main/default/classes/HttpMockTest.cls
@@ -239,6 +239,50 @@ private class HttpMockTest {
     }
 
     @IsTest
+    static void staticResourceBody() {
+        String staticResourceName = 'responseBody';
+
+        new HttpMock()
+            .whenGetOn('/api/v1').staticResource(staticResourceName)
+            .mock();
+
+        Test.startTest();
+        HttpResponse response = new TestApi().makeCallout('GET', '/api/v1');
+        Test.stopTest();
+
+        SampleResponseBody responseBody = (SampleResponseBody) JSON.deserialize(response.getBody(), SampleResponseBody.class);
+        Assert.areEqual('responseBody', responseBody.name, 'Name should be responseBody');
+        Assert.areEqual(1, responseBody.order, 'Order should be 1');
+        Assert.isTrue(responseBody.active, 'Active should be true');
+        Assert.areEqual(new List<String>{'This is a sample JSON request body for API testing.'}, responseBody.additionalDetails, 'Additional details list should be the same');
+    }
+
+    class SampleResponseBody {
+        public String name;
+        public Integer order;
+        public Boolean active;
+        public List<String> additionalDetails;
+    }
+
+    @IsTest
+    static void staticResourceNotFound() {
+        String staticResourceName = 'aResourceThatDoesNotExist12345';
+
+        Test.startTest();
+        Exception caughtEx;
+        try {
+            new HttpMock()
+                .whenGetOn('/api/v1').staticResource(staticResourceName)
+                .mock();
+        } catch (Exception ex) {
+            caughtEx = ex;
+        }
+        Test.stopTest();           
+        
+        Assert.isInstanceOfType(caughtEx, HttpMock.StaticResourceNotFoundException.class, 'Exception should be StaticResourceNotFoundException');
+    }
+
+    @IsTest
     static void statusCodeOk() {
         new HttpMock()
             .whenGetOn('/api/v1').statusCodeOk()

--- a/force-app/main/default/staticresources/responseBody.json
+++ b/force-app/main/default/staticresources/responseBody.json
@@ -1,0 +1,6 @@
+{
+    "name": "responseBody",
+    "order": 1,
+    "active": true,
+    "additionalDetails": [ "This is a sample JSON request body for API testing." ]
+}

--- a/force-app/main/default/staticresources/responseBody.resource-meta.xml
+++ b/force-app/main/default/staticresources/responseBody.resource-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/json</contentType>
+    <description>A sample response body for testing static resource loading for http mocking</description>
+</StaticResource>


### PR DESCRIPTION
When statically mocking http requests, Salesforce has both a [Single Request](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_staticresourcecalloutmock.htm) and [Multiple Request](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_multistaticresourcecalloutmock.htm) class that allows support for leveraging static resources to build out complex mock response bodies. Within HTTP-Mock-Lib, we can add that support by performing queries on the Static Resource table to retrieve a specific static resource body. Below is an example of its usage:

```
// testResponse.json
{
    "name": "responseBody",
    "order": 1,
    "active": true,
    "additionalDetails": [ "This is a sample JSON request body for API testing." ]
}
```

```
// TestImplementation.cls
...
new HttpMock().whenGetOn('/api/v1').staticResource('staticResourceAPIName').statusCodeAccepted().mock();
...
```